### PR TITLE
Replace httpretty with mocket

### DIFF
--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -11,5 +11,4 @@ pytest
 pytest-cov
 pytest-env
 pytest-freezer
-# pinning to 1.0.5 pending this issue https://github.com/gabrielfalcao/HTTPretty/issues/425
-httpretty==1.0.5
+mocket

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -92,6 +92,10 @@ coverage[toml]==7.6.1 \
     --hash=sha256:fc5a77d0c516700ebad189b587de289a20a78324bc54baee03dd486f0855d234 \
     --hash=sha256:fd21f6ae3f08b41004dfb433fa895d858f3f5979e7762d052b12aef444e29afc
     # via pytest-cov
+decorator==5.1.1 \
+    --hash=sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330 \
+    --hash=sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186
+    # via mocket
 distlib==0.3.8 \
     --hash=sha256:034db59a0b96f8ca18035f36290806a9a6e6bd9d1ff91e45a7f172eb17e51784 \
     --hash=sha256:1530ea13e350031b6312d8580ddb6b27a104275a31106523b8f123787f494f64
@@ -104,9 +108,10 @@ freezegun==1.5.1 \
     --hash=sha256:b29dedfcda6d5e8e083ce71b2b542753ad48cfec44037b3fc79702e2980a89e9 \
     --hash=sha256:bf111d7138a8abe55ab48a71755673dbaa4ab87f4cff5634a4442dfec34c15f1
     # via pytest-freezer
-httpretty==1.0.5 \
-    --hash=sha256:e53c927c4d3d781a0761727f1edfad64abef94e828718e12b672a678a8b3e0b5
-    # via -r requirements.dev.in
+h11==0.14.0 \
+    --hash=sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d \
+    --hash=sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761
+    # via mocket
 identify==2.6.0 \
     --hash=sha256:cb171c685bdc31bcc4c1734698736a7d5b6c8bf2e0c15117f4d469c8640ae5cf \
     --hash=sha256:e79ae4406387a9d300332b5fd366d8994f1525e8414984e1a59e058b2eda2dd0
@@ -115,6 +120,10 @@ iniconfig==2.0.0 \
     --hash=sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3 \
     --hash=sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374
     # via pytest
+mocket==3.13.2 \
+    --hash=sha256:1a6b3658e668c2bc1fe8442df7840b5b77318544f5c157a9952776b17ebff2a2 \
+    --hash=sha256:e3b61cb2af2aa696a877b1d2723c0efebbb768e8dc20f076ff2da8d0421742c0
+    # via -r requirements.dev.in
 nodeenv==1.9.1 \
     --hash=sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f \
     --hash=sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9
@@ -142,6 +151,10 @@ pre-commit==4.0.1 \
     --hash=sha256:80905ac375958c0444c65e9cebebd948b3cdb518f335a091a670a89d652139d2 \
     --hash=sha256:efde913840816312445dc98787724647c65473daefe420785f885e8ed9a06878
     # via -r requirements.dev.in
+puremagic==1.28 \
+    --hash=sha256:195893fc129657f611b86b959aab337207d6df7f25372209269ed9e303c1a8c0 \
+    --hash=sha256:e16cb9708ee2007142c37931c58f07f7eca956b3472489106a7245e5c3aa1241
+    # via mocket
 pyproject-hooks==1.1.0 \
     --hash=sha256:4b37730834edbd6bd37f26ece6b44802fb1c1ee2ece0e54ddff8bfc06db86965 \
     --hash=sha256:7ceeefe9aec63a1064c18d939bdc3adf2d8aa1988a510afec15151578b232aa2
@@ -253,6 +266,12 @@ six==1.16.0 \
     # via
     #   -c requirements.prod.txt
     #   python-dateutil
+urllib3==2.2.2 \
+    --hash=sha256:a448b2f64d686155468037e1ace9f2d2199776e17f0a46610480d311f73e3472 \
+    --hash=sha256:dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168
+    # via
+    #   -c requirements.prod.txt
+    #   mocket
 virtualenv==20.26.3 \
     --hash=sha256:4c43a2a236279d9ea36a0d76f98d84bd6ca94ac4e0f4a3b9d46d05e10fea542a \
     --hash=sha256:8cc4a31139e796e9a7de2cd5cf2489de1217193116a8fd42328f1bd65f434589

--- a/tests/webserver/test_github.py
+++ b/tests/webserver/test_github.py
@@ -1,13 +1,13 @@
 from unittest.mock import patch
 
-import httpretty
 import pytest
+from mocket import Mocket, mocketize
 
 from bennettbot import scheduler
 from bennettbot.job_configs import build_config
 
 from ..assertions import assert_job_matches, assert_slack_client_sends_messages
-from ..mock_http_request import httpretty_register
+from ..mock_http_request import mocket_register
 from ..time_helpers import T0, T
 
 
@@ -58,9 +58,9 @@ def test_valid_auth_header(web_client):
     assert rsp.status_code == 200
 
 
-@httpretty.activate(allow_net_connect=False)
+@mocketize(strict_mode=True)
 def test_on_closed_merged_pr(web_client):
-    httpretty_register({"chat.postMessage": {"ok": True}})
+    mocket_register({"chat.postMessage": {"ok": True}})
     headers = {"X-Hub-Signature": "sha1=3e09e676b4a62b634401b44b4c4ff1f58404e746"}
 
     with patch("bennettbot.webserver.github.config", new=dummy_config):
@@ -74,12 +74,14 @@ def test_on_closed_merged_pr(web_client):
     assert_slack_client_sends_messages(messages_kwargs=[])
 
 
-@httpretty.activate(allow_net_connect=False)
+@mocketize(strict_mode=True)
 def test_on_closed_merged_pr_with_suppression(web_client):
-    httpretty_register({"chat.postMessage": [{"ok": True}]})
+    mocket_register({"chat.postMessage": [{"ok": True}]})
     scheduler.schedule_suppression("test_deploy", T(-60), T(60))
 
-    headers = {"X-Hub-Signature": "sha1=3e09e676b4a62b634401b44b4c4ff1f58404e746"}
+    headers = {
+        "X-Hub-Signature": "sha1=3e09e676b4a62b634401b44b4c4ff1f58404e746",
+    }
 
     with patch("bennettbot.webserver.github.config", new=dummy_config):
         rsp = web_client.post("/github/test/", data=PAYLOAD_PR_CLOSED, headers=headers)
@@ -90,7 +92,7 @@ def test_on_closed_merged_pr_with_suppression(web_client):
     assert_job_matches(jj[0], "test_deploy", {}, "#some-team", T(60), None)
 
     # message sent for suppression
-    assert len(httpretty.latest_requests()) == 1
+    assert len(Mocket.request_list()) == 1
     assert_slack_client_sends_messages(
         messages_kwargs=[{"text": f"suppressed until {T(60)}", "channel": "#some-team"}]
     )


### PR DESCRIPTION
httpretty has not been actively maintained for a while (there are a lot of outstanding PRs and issues, and the last commit on main was 3 years ago). We were already pinning it because of one [bug](https://github.com/gabrielfalcao/HTTPretty/issues/425), and it's now also [incompatible with the latest version of urllib3](https://github.com/gabrielfalcao/HTTPretty/issues/484), which is why the latest update-dependencies PR is failing.

[mocket](https://github.com/mindflayer/python-mocket/) does all the same things as httpretty and more (it does have a plugin that aims to be a dropin replacement for httpretty, but it doesn't cover all the ways that we use it). In any case, replacing our use of httpretty with mocket is quite straightforward.