### PR TITLE
Move bennettbot to bennettoxford Github org

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: CI
 
 env:
   IMAGE_NAME: bennettbot
-  PUBLIC_IMAGE_NAME: ghcr.io/ebmdatalab/bennettbot
+  PUBLIC_IMAGE_NAME: ghcr.io/bennettoxford/bennettbot
   REGISTRY: ghcr.io
   SSH_AUTH_SOCK: /tmp/agent.sock
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -213,11 +213,11 @@ To deploy manually:
 just docker/build prod
 
 # tag image and push
-docker tag bennettbot ghcr.io/ebmdatalab/bennettbot:latest
-docker push ghcr.io/ebmdatalab/bennettbot:latest
+docker tag bennettbot ghcr.io/bennettoxford/bennettbot:latest
+docker push ghcr.io/bennettoxford/bennettbot:latest
 
 # get the SHA for the latest image
-SHA=$(docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/ebmdatalab/bennettbot:latest)
+SHA=$(docker inspect --format='{{index .RepoDigests 0}}' ghcr.io/bennettoxford/bennettbot:latest)
 ```
 
 On dokku3:

--- a/bennettbot/job_configs.py
+++ b/bennettbot/job_configs.py
@@ -64,7 +64,7 @@ raw_config = {
         # The file it's fetching is just a standard python file, not a fabfile,
         # but the job will fetch and write it as 'fabfile.py' irrespective of its
         # original name - so we need to run it with `python fabfile.py`
-        "fabfile": "https://raw.githubusercontent.com/ebmdatalab/bennettbot/main/workspace/test/jobs.py",
+        "fabfile": "https://raw.githubusercontent.com/bennettoxford/bennettbot/main/workspace/test/jobs.py",
         "jobs": {
             "hello_world": {
                 "run_args_template": "python fabfile.py",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -104,7 +104,7 @@ EXPOSE 9999
 # some basic metadata.
 LABEL org.opencontainers.image.title="bennettbot" \
       org.opencontainers.image.description="bennettbot" \
-      org.opencontainers.image.source="https://github.com/ebmdatalab/bennettbot"
+      org.opencontainers.image.source="https://github.com/bennettoxford/bennettbot"
 
 # copy application code
 COPY . /app

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
       # should speed up the build in CI, where we have a cold cache
       cache_from:  # should speed up the build in CI, where we have a cold cache
         - ghcr.io/opensafely-core/base-docker
-        - ghcr.io/ebmdatalab/bennettbot
+        - ghcr.io/bennettoxford/bennettbot
       args:
         # this makes the image work for later cache_from: usage
         - BUILDKIT_INLINE_CACHE=1

--- a/workspace/workflows/config.py
+++ b/workspace/workflows/config.py
@@ -128,7 +128,7 @@ SKIPPED_WORKFLOWS_ON_MAIN = {
     "opensafely-core/sqlrunner": [
         37329087,  # [On PR] Auto merge Dependabot PRs
     ],
-    "ebmdatalab/bennettbot": [
+    "bennettoxford/bennettbot": [
         32719413,  # [On PR] Auto merge Dependabot PRs
     ],
 }


### PR DESCRIPTION
* some of these things will auto-redirect from the old name, although not ghrc.io
