### PR TITLE
Parametrize threshold

### DIFF
--- a/bennettbot/job_configs.py
+++ b/bennettbot/job_configs.py
@@ -498,15 +498,15 @@ raw_config = {
         "description": "Codespaces monitoring tools",
         "jobs": {
             "at_risk": {
-                "run_args_template": "python codespaces.py",
+                "run_args_template": "python codespaces.py {threshold_in_days}",
                 "report_stdout": True,
                 "report_format": "blocks",
             },
         },
         "slack": [
             {
-                "command": "at risk",
-                "help": "Shows the Codespaces that are at risk of being deleted",
+                "command": "at risk [threshold_in_days]",
+                "help": "Report Codespaces at risk of being deleted",
                 "action": "schedule_job",
                 "job_type": "at_risk",
                 "delay_seconds": 0,

--- a/workspace/codespaces/codespaces.py
+++ b/workspace/codespaces/codespaces.py
@@ -158,13 +158,19 @@ def main(threshold_in_days):
         list_items = [
             RichTextSectionElement(
                 elements=[
+                    Text(text="User", style=BOLD),
+                    Text(text=": "),
                     Text(text=cs.owner, style=CODE),
-                    Text(text=f" on {cs.retention_expires_at:%A, %b %d at %H:%M}"),
-                    Text(text=f" ({remaining_days_text}) "),
-                    Text(text="repo", style=BOLD),
+                    Text(text=" Repo", style=BOLD),
                     Text(text=": "),
                     Text(text=cs.repo, style=CODE),
-                    Text(text=" ID", style=BOLD),
+                    Text(text=" Deletion", style=BOLD),
+                    Text(text=": "),
+                    Text(
+                        text=f"in {remaining_days_text} "
+                        f"({cs.retention_expires_at:%A, %b %d at %H:%M}) "
+                    ),
+                    Text(text="ID", style=BOLD),
                     Text(text=": "),
                     Text(text=cs.name, style=CODE),
                     Text(text=" Retention", style=BOLD),

--- a/workspace/codespaces/codespaces.py
+++ b/workspace/codespaces/codespaces.py
@@ -9,6 +9,7 @@ As of 2025-01, that's located at:
 https://github.com/ebmdatalab/team-manual/blob/main/docs/tech-group/playbooks/codespaces.md
 """
 
+import argparse
 import collections
 import datetime
 import json
@@ -126,10 +127,8 @@ def is_at_risk(codespace, threshold_in_days):
         return False
 
 
-def main():
+def main(threshold_in_days):
     org = "opensafely"
-    # Arbitrary threshold. Gives us a bit more than a week to respond.
-    threshold_in_days = 10
 
     # Fetch info on org CodeSpaces at risk from GitHub API.
     records = fetch(URL_PATTERN.format(org=org), "codespaces")
@@ -215,4 +214,14 @@ def main():
 
 
 if __name__ == "__main__":
-    print(main())
+    parser = argparse.ArgumentParser(
+        description="Report Codespaces at risk of being deleted"
+    )
+    parser.add_argument(
+        "threshold_in_days",
+        type=int,
+        help="Threshold in days for Codespaces to be considered 'at risk'",
+    )
+    args = parser.parse_args()
+
+    print(main(args.threshold_in_days))

--- a/workspace/codespaces/codespaces.py
+++ b/workspace/codespaces/codespaces.py
@@ -28,6 +28,7 @@ from slack_sdk.models.blocks import (
 CODE = RichTextElementParts.TextStyle(code=True)
 BOLD = RichTextElementParts.TextStyle(bold=True)
 Text = RichTextElementParts.Text
+Emoji = RichTextElementParts.Emoji
 
 
 URL_PATTERN = "https://api.github.com/orgs/{org}/codespaces"
@@ -191,9 +192,10 @@ def main(threshold_in_days):
                 Text(
                     text=(
                         " Codespaces with unsaved work at risk (expiring within "
-                        f"{threshold_in_days} days) :tada:"
+                        f"{threshold_in_days} days) "
                     )
                 ),
+                Emoji(name="tada"),
             ]
         )
         list_items = []


### PR DESCRIPTION
Allow the Slack request to specify the threshold rather than hard-coding it. We
may fine-tune this depending on how much output we get and what proves most
useful to users. This makes it easier to do that experimentation, change Slack
reminders etc.

I'll update the playbook with the current threshold and rationale. That'll be a
separate PR as it's a separate repo (team-manual).

As discussed in Slack:
https://bennettoxford.slack.com/archives/C069SADHP1Q/p1736434022622129?thread_ts=1736427127.238419&cid=C069SADHP1Q