### PR TITLE
OpenPrescribing has moved to the new GH org

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -147,7 +147,7 @@ The following slack environment variables need to be set:
 - `SLACK_APP_USERNAME`: The app's default name (and the name users will refer to the Bot as in Slack); found under Features > App Home
 
 The following webhook environment variables need to be set. These relate to callbacks from
-OpenPrescribing, and are configured at https://github.com/ebmdatalab/openprescribing/settings/hooks/85994427.
+OpenPrescribing, and are configured at https://github.com/bennettoxford/openprescribing/settings/hooks/85994427.
 - `GITHUB_WEBHOOK_SECRET`
 - `WEBHOOK_ORIGIN`
 

--- a/bennettbot/job_configs.py
+++ b/bennettbot/job_configs.py
@@ -101,7 +101,7 @@ raw_config = {
     "op": {
         "restricted": True,
         "description": "OpenPrescribing deployment and tools",
-        "fabfile": "https://raw.githubusercontent.com/ebmdatalab/openprescribing/main/fabfile.py",
+        "fabfile": "https://raw.githubusercontent.com/bennettoxford/openprescribing/main/fabfile.py",
         "default_channel": "#team-rap",
         "jobs": {
             "deploy": {

--- a/bennettbot/settings.py
+++ b/bennettbot/settings.py
@@ -47,10 +47,10 @@ BOT_CHECK_FILE = env.path(
 )
 
 # Should match "Payload URL" from
-# https://github.com/ebmdatalab/openprescribing/settings/hooks/85994427
+# https://github.com/bennettoxford/openprescribing/settings/hooks/85994427
 WEBHOOK_ORIGIN = env.str("WEBHOOK_ORIGIN")
 
-# "Secret" from https://github.com/ebmdatalab/openprescribing/settings/hooks/85994427
+# "Secret" from https://github.com/bennettoxford/openprescribing/settings/hooks/85994427
 GITHUB_WEBHOOK_SECRET = env.str("GITHUB_WEBHOOK_SECRET").encode("ascii")
 
 # Path to credentials of gdrive@ebmdatalab.iam.gserviceaccount.com GCP service account

--- a/bennettbot/webserver/github.py
+++ b/bennettbot/webserver/github.py
@@ -15,7 +15,7 @@ def handle_github_webhook(project):
 
     The webhook is configured at:
 
-        https://github.com/ebmdatalab/openprescribing/settings/hooks/85994427
+        https://github.com/bennettoxford/openprescribing/settings/hooks/85994427
     """
 
     verify_signature(request)

--- a/workspace/workflows/config.py
+++ b/workspace/workflows/config.py
@@ -61,7 +61,7 @@ REPOS = {
         "team": "Team REX",
     },
     "openprescribing": {
-        "org": "ebmdatalab",
+        "org": "bennettoxford",
         "team": "Team RAP",
     },
     "opensafely-cli": {


### PR DESCRIPTION
* the redirect means this will work using either org name, but we should amend