### PR TITLE
Standup rota: Use people-related classes and notify them in Slack

### DIFF
--- a/tests/workspace/test_people.py
+++ b/tests/workspace/test_people.py
@@ -1,17 +1,14 @@
-from workspace.utils.people import (
-    People,
-    get_person_from_github_username,
-)
+from workspace.utils.people import People
 
 
 def test_get_person_from_github_username():
-    result = get_person_from_github_username("lucyb")
+    result = People.by_github_username("lucyb")
 
-    assert result == People.LUCY.value
+    assert result == People.LUCY
 
 
 def test_get_person_from_github_username_returns_default():
-    result = get_person_from_github_username("TestUser")
+    result = People.by_github_username("TestUser")
 
     assert result.human_readable == "TestUser"
     assert result.github_username == "TestUser"
@@ -19,6 +16,6 @@ def test_get_person_from_github_username_returns_default():
 
 
 def test_get_formatted_slack_username_returns_slack_user_id():
-    result = People.LUCY.value.get_formatted_slack_username()
+    result = People.LUCY.get_formatted_slack_username()
 
     assert result == "<@U035FT48KEK>"

--- a/tests/workspace/test_people.py
+++ b/tests/workspace/test_people.py
@@ -1,6 +1,5 @@
 from workspace.utils.people import (
     People,
-    get_formatted_slack_username,
     get_person_from_github_username,
 )
 
@@ -20,6 +19,6 @@ def test_get_person_from_github_username_returns_default():
 
 
 def test_get_formatted_slack_username_returns_slack_user_id():
-    result = get_formatted_slack_username(People.LUCY.value)
+    result = People.LUCY.value.get_formatted_slack_username()
 
     assert result == "<@U035FT48KEK>"

--- a/tests/workspace/test_people.py
+++ b/tests/workspace/test_people.py
@@ -14,6 +14,7 @@ def test_get_person_from_github_username():
 def test_get_person_from_github_username_returns_default():
     result = get_person_from_github_username("TestUser")
 
+    assert result.human_readable == "TestUser"
     assert result.github_username == "TestUser"
     assert result.slack_username == "TestUser"
 

--- a/tests/workspace/test_people.py
+++ b/tests/workspace/test_people.py
@@ -19,3 +19,7 @@ def test_formatted_slack_username():
     result = People.LUCY.formatted_slack_username
 
     assert result == "<@U035FT48KEK>"
+
+
+def test_iteration():
+    assert isinstance([person for person in People], list)

--- a/tests/workspace/test_people.py
+++ b/tests/workspace/test_people.py
@@ -15,7 +15,7 @@ def test_get_person_from_github_username_returns_default():
     assert result.slack_username == "TestUser"
 
 
-def test_get_formatted_slack_username_returns_slack_user_id():
-    result = People.LUCY.get_formatted_slack_username()
+def test_formatted_slack_username():
+    result = People.LUCY.formatted_slack_username
 
     assert result == "<@U035FT48KEK>"

--- a/tests/workspace/test_standup_rota.py
+++ b/tests/workspace/test_standup_rota.py
@@ -58,7 +58,7 @@ def test_daily_rota_odd_week(freezer):
         },
         {
             "text": {
-                "text": "Monday: Jon (backup: Mike)",
+                "text": "Monday: <@U023ZG5H24R> (backup: Mike)",
                 "type": "mrkdwn",
             },
             "type": "section",
@@ -77,7 +77,7 @@ def test_daily_rota_even_week(freezer):
         },
         {
             "text": {
-                "text": "Wednesday: Mary (backup: Steve)",
+                "text": "Wednesday: <@U07LKQ06Q8L> (backup: Steve)",
                 "type": "mrkdwn",
             },
             "type": "section",

--- a/workspace/dependabot/jobs.py
+++ b/workspace/dependabot/jobs.py
@@ -37,7 +37,7 @@ class DependabotRotaReporter(RotaReporter):
     ) -> str:
         checker = rota[monday]
         if this_or_next == "this":
-            checker = checker.get_formatted_slack_username()
+            checker = checker.formatted_slack_username
         else:
             checker = checker.human_readable
         return f"To review dependabot PRs {this_or_next} week ({self.format_week(monday)}): {checker}"

--- a/workspace/dependabot/jobs.py
+++ b/workspace/dependabot/jobs.py
@@ -11,6 +11,7 @@ class DependabotRotaReporter(RotaReporter):
     The candidates are currently Team Rex (except Katie).
     If the candidate definition or Team changes this will affect
     the rota offset and the rota will restart at an arbitrary point.
+    Consider redesigning class to include an offset if that happens.
     """
 
     def get_rota(self) -> dict:

--- a/workspace/dependabot/jobs.py
+++ b/workspace/dependabot/jobs.py
@@ -1,7 +1,7 @@
 from datetime import date, timedelta
 from itertools import cycle, islice
 
-from workspace.utils.people import TEAM_REX, People, get_formatted_slack_username
+from workspace.utils.people import TEAM_REX, People
 from workspace.utils.rota import RotaReporter
 
 
@@ -37,7 +37,7 @@ class DependabotRotaReporter(RotaReporter):
     ) -> str:
         checker = rota[monday]
         if this_or_next == "this":
-            checker = get_formatted_slack_username(checker.value)
+            checker = checker.value.get_formatted_slack_username()
         else:
             checker = checker.name.title()
         return f"To review dependabot PRs {this_or_next} week ({self.format_week(monday)}): {checker}"

--- a/workspace/dependabot/jobs.py
+++ b/workspace/dependabot/jobs.py
@@ -37,9 +37,9 @@ class DependabotRotaReporter(RotaReporter):
     ) -> str:
         checker = rota[monday]
         if this_or_next == "this":
-            checker = checker.value.get_formatted_slack_username()
+            checker = checker.get_formatted_slack_username()
         else:
-            checker = checker.name.title()
+            checker = checker.human_readable
         return f"To review dependabot PRs {this_or_next} week ({self.format_week(monday)}): {checker}"
 
 

--- a/workspace/report/generate_report.py
+++ b/workspace/report/generate_report.py
@@ -5,10 +5,7 @@ import os
 import requests
 
 from workspace.utils.blocks import get_basic_header_and_text_blocks
-from workspace.utils.people import (
-    get_formatted_slack_username,
-    get_person_from_github_username,
-)
+from workspace.utils.people import get_person_from_github_username
 
 
 URL = "https://api.github.com/graphql"
@@ -174,7 +171,7 @@ def get_status_and_summary(card):  # pragma: no cover
     title = card["content"]["title"]
     url = card["content"].get("bodyUrl")
     assignees = " / ".join(
-        get_formatted_slack_username(get_person_from_github_username(node["login"]))
+        get_person_from_github_username(node["login"]).get_formatted_slack_username()
         for node in card["content"]["assignees"]["nodes"]
     )
 

--- a/workspace/report/generate_report.py
+++ b/workspace/report/generate_report.py
@@ -5,7 +5,7 @@ import os
 import requests
 
 from workspace.utils.blocks import get_basic_header_and_text_blocks
-from workspace.utils.people import get_person_from_github_username
+from workspace.utils.people import People
 
 
 URL = "https://api.github.com/graphql"
@@ -171,7 +171,7 @@ def get_status_and_summary(card):  # pragma: no cover
     title = card["content"]["title"]
     url = card["content"].get("bodyUrl")
     assignees = " / ".join(
-        get_person_from_github_username(node["login"]).get_formatted_slack_username()
+        People.by_github_username(node["login"]).get_formatted_slack_username()
         for node in card["content"]["assignees"]["nodes"]
     )
 

--- a/workspace/report/generate_report.py
+++ b/workspace/report/generate_report.py
@@ -171,7 +171,7 @@ def get_status_and_summary(card):  # pragma: no cover
     title = card["content"]["title"]
     url = card["content"].get("bodyUrl")
     assignees = " / ".join(
-        People.by_github_username(node["login"]).get_formatted_slack_username()
+        People.by_github_username(node["login"]).formatted_slack_username
         for node in card["content"]["assignees"]["nodes"]
     )
 

--- a/workspace/standup/jobs.py
+++ b/workspace/standup/jobs.py
@@ -38,11 +38,12 @@ def weekly_rota(args):
     header = "Team Rex stand ups this week"
     days = "\n".join(
         [
-            f"{day_of_week.title()}: {PAIRS[day_of_week][primary]} (backup: {PAIRS[day_of_week][secondary]})"
+            f"{day_of_week.title()}: "
+            f"{PAIRS[day_of_week][primary]} "
+            f"(backup: {PAIRS[day_of_week][secondary]})"
             for day_of_week in PAIRS.keys()
         ]
     )
-
     return json.dumps(blocks.get_basic_header_and_text_blocks(header, days))
 
 
@@ -53,7 +54,11 @@ def daily_rota(args):
     primary = is_even_week(rota_date)
     secondary = 0 if primary else 1
     header = "Team Rex stand up"
-    body = f"{day_of_week.title()}: {PAIRS[day_of_week][primary]} (backup: {PAIRS[day_of_week][secondary]})"
+    body = (
+        f"{day_of_week.title()}: "
+        f"{PAIRS[day_of_week][primary]} "
+        f"(backup: {PAIRS[day_of_week][secondary]})"
+    )
 
     return json.dumps(blocks.get_basic_header_and_text_blocks(header, body))
 

--- a/workspace/standup/jobs.py
+++ b/workspace/standup/jobs.py
@@ -57,7 +57,7 @@ def daily_rota(args):
     header = "Team Rex stand up"
     body = (
         f"{day_of_week.title()}: "
-        f"{PAIRS[day_of_week][primary].value.human_readable} "
+        f"{PAIRS[day_of_week][primary].value.get_formatted_slack_username()} "
         f"(backup: {PAIRS[day_of_week][secondary].value.human_readable})"
     )
 

--- a/workspace/standup/jobs.py
+++ b/workspace/standup/jobs.py
@@ -40,8 +40,8 @@ def weekly_rota(args):
     days = "\n".join(
         [
             f"{day_of_week.title()}: "
-            f"{PAIRS[day_of_week][primary].value.human_readable} "
-            f"(backup: {PAIRS[day_of_week][secondary].value.human_readable})"
+            f"{PAIRS[day_of_week][primary].human_readable} "
+            f"(backup: {PAIRS[day_of_week][secondary].human_readable})"
             for day_of_week in PAIRS.keys()
         ]
     )
@@ -57,8 +57,8 @@ def daily_rota(args):
     header = "Team Rex stand up"
     body = (
         f"{day_of_week.title()}: "
-        f"{PAIRS[day_of_week][primary].value.get_formatted_slack_username()} "
-        f"(backup: {PAIRS[day_of_week][secondary].value.human_readable})"
+        f"{PAIRS[day_of_week][primary].get_formatted_slack_username()} "
+        f"(backup: {PAIRS[day_of_week][secondary].human_readable})"
     )
 
     return json.dumps(blocks.get_basic_header_and_text_blocks(header, body))

--- a/workspace/standup/jobs.py
+++ b/workspace/standup/jobs.py
@@ -57,7 +57,7 @@ def daily_rota(args):
     header = "Team Rex stand up"
     body = (
         f"{day_of_week.title()}: "
-        f"{PAIRS[day_of_week][primary].get_formatted_slack_username()} "
+        f"{PAIRS[day_of_week][primary].formatted_slack_username} "
         f"(backup: {PAIRS[day_of_week][secondary].human_readable})"
     )
 

--- a/workspace/standup/jobs.py
+++ b/workspace/standup/jobs.py
@@ -3,12 +3,13 @@ import json
 from datetime import date, datetime, timedelta
 
 from workspace.utils import blocks
+from workspace.utils.people import People
 
 
 PAIRS = {
-    "monday": ["Mike", "Jon"],
-    "wednesday": ["Mary", "Steve"],
-    "friday": ["Thomas", "Katie"],
+    "monday": [People.MIKE, People.JON],
+    "wednesday": [People.MARY, People.STEVE],
+    "friday": [People.THOMAS, People.KATIE],
 }
 
 
@@ -39,8 +40,8 @@ def weekly_rota(args):
     days = "\n".join(
         [
             f"{day_of_week.title()}: "
-            f"{PAIRS[day_of_week][primary]} "
-            f"(backup: {PAIRS[day_of_week][secondary]})"
+            f"{PAIRS[day_of_week][primary].value.human_readable} "
+            f"(backup: {PAIRS[day_of_week][secondary].value.human_readable})"
             for day_of_week in PAIRS.keys()
         ]
     )
@@ -56,8 +57,8 @@ def daily_rota(args):
     header = "Team Rex stand up"
     body = (
         f"{day_of_week.title()}: "
-        f"{PAIRS[day_of_week][primary]} "
-        f"(backup: {PAIRS[day_of_week][secondary]})"
+        f"{PAIRS[day_of_week][primary].value.human_readable} "
+        f"(backup: {PAIRS[day_of_week][secondary].value.human_readable})"
     )
 
     return json.dumps(blocks.get_basic_header_and_text_blocks(header, body))

--- a/workspace/utils/people.py
+++ b/workspace/utils/people.py
@@ -18,10 +18,14 @@ class PersonCollection(type):
     """Metaclass for collections of Person instances."""
 
     def __init__(cls, name, bases, namespace):
+        # dict mapping github_username to People instances, for later lookups.
+        cls._by_github_username = {}
+
         people_items = [
             item for item in namespace.items() if isinstance(item[1], Person)
         ]
         for attribute_name, person in people_items:
+            cls._by_github_username[person.github_username] = person
             # Populate human_readable based on attribute value if not set explicitly.
             if not person.human_readable:
                 person.human_readable = attribute_name.title().replace("_", " ")
@@ -66,16 +70,8 @@ class People(metaclass=PersonCollection):
     TOM_P = Person("remlapmot", "U07L0L0SS6M")
     TOM_W = Person("madwort", "U019R5FJ7G8")
 
-    # Dict mapping github_username to People, constructed lazily and cached the
-    # first time it's needed. Can't be built in the class definition as we
-    # can't introspect the class until it is constructed.
-    _by_github_username = None
-
     @classmethod
     def by_github_username(cls, github_username):
-        if cls._by_github_username is None:
-            cls._by_github_username = {person.github_username: person for person in cls}
-
         default = Person(
             human_readable=github_username,
             github_username=github_username,

--- a/workspace/utils/people.py
+++ b/workspace/utils/people.py
@@ -1,55 +1,70 @@
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass(order=True)
 class Person:
-    human_readable: str
     github_username: str
     slack_username: str
+    # Optional because this is mostly set in PersonCollection.__init__().
+    human_readable: Optional[str] = ""
 
     @property
     def formatted_slack_username(self) -> str:
         return f"<@{self.slack_username}>"
 
 
-class PersonIterator(type):
-    """Metaclass to iterate on Person instances in class attributes.
+class PersonCollection(type):
+    """Metaclass for collections of Person instances."""
 
-    This is to allow `for person in People` or similar to work."""
+    def __init__(cls, name, bases, namespace):
+        people_items = [
+            item for item in namespace.items() if isinstance(item[1], Person)
+        ]
+        for attribute_name, person in people_items:
+            # Populate human_readable based on attribute value if not set explicitly.
+            if not person.human_readable:
+                person.human_readable = attribute_name.title().replace("_", " ")
+
+        super().__init__(name, bases, namespace)
 
     def __iter__(cls):
+        # Enable iteration by `for person in People` or similar to work.
         return iter(
             sorted(value for value in vars(cls).values() if isinstance(value, Person))
         )
 
 
-class People(metaclass=PersonIterator):
+class People(metaclass=PersonCollection):
     """Tech team members' GitHub and Slack usernames."""
 
     # Find a Slack user's username by right-clicking on their name in the Slack
     # app and clicking "Copy link".
 
-    ALICE = Person("Alice", "alarthast", "U07KX6L3CMA")
-    BECKY = Person("Becky", "rebkwok", "U01SP5JLBFD")
-    BEN_BC = Person("Ben BC", "benbc", "U01SPCP06Q1")
-    CATHERINE = Person("Catherine", "CLStables", "U036A6LTR7D")
-    DAVE = Person("Dave", "evansd", "UAXE5V4RG")
-    ELI = Person("Eli", "eli-miriam", "U07LHEJ9TS4")
-    IAIN = Person("Iain", "iaindillingham", "U01S6BLGK28")
-    JON = Person("Jon", "Jongmassey", "U023ZG5H24R")
-    KATIE = Person("Katie", "KatieB5", "U07KUKWBGKV")
-    LUCY = Person("Lucy", "lucyb", "U035FT48KEK")
-    MARY = Person("Mary", "Mary-Anya", "U07LKQ06Q8L")
-    MILAN = Person("Milan", "milanwiedemann", "U02GPV8NNU9")
-    MIKE = Person("Mike", "mikerkelly", "U07KKL4PJJY")
-    PETER = Person("Peter", "inglesp", "U4N1YPAP7")
-    PROVIDENCE = Person("Providence", "Providence-o", "U07AGDM6ZJN")
-    RICHARD = Person("Richard", "rw251", "U07QEMHUUMD")
-    SIMON = Person("Simon", "bloodearnest", "U01AMBZUT47")
-    STEVE = Person("Steve", "StevenMaude", "U01TJP3CG76")
-    THOMAS = Person("Thomas", "tomodwyer", "U01UQ0T2M7V")
-    TOM_P = Person("Tom P", "remlapmot", "U07L0L0SS6M")
-    TOM_W = Person("Tom W", "madwort", "U019R5FJ7G8")
+    # human_readable is mostly set by PersonCollection.__init__() but can be
+    # overriden as the third argument if required. This avoids the need to
+    # explicitly specify it for most people.
+    ALICE = Person("alarthast", "U07KX6L3CMA")
+    BECKY = Person("rebkwok", "U01SP5JLBFD")
+    BEN_BC = Person("benbc", "U01SPCP06Q1", "Ben BC")
+    CATHERINE = Person("CLStables", "U036A6LTR7D")
+    DAVE = Person("evansd", "UAXE5V4RG")
+    ELI = Person("eli-miriam", "U07LHEJ9TS4")
+    IAIN = Person("iaindillingham", "U01S6BLGK28")
+    JON = Person("Jongmassey", "U023ZG5H24R")
+    KATIE = Person("KatieB5", "U07KUKWBGKV")
+    LUCY = Person("lucyb", "U035FT48KEK")
+    MARY = Person("Mary-Anya", "U07LKQ06Q8L")
+    MILAN = Person("milanwiedemann", "U02GPV8NNU9")
+    MIKE = Person("mikerkelly", "U07KKL4PJJY")
+    PETER = Person("inglesp", "U4N1YPAP7")
+    PROVIDENCE = Person("Providence-o", "U07AGDM6ZJN")
+    RICHARD = Person("rw251", "U07QEMHUUMD")
+    SIMON = Person("bloodearnest", "U01AMBZUT47")
+    STEVE = Person("StevenMaude", "U01TJP3CG76")
+    THOMAS = Person("tomodwyer", "U01UQ0T2M7V")
+    TOM_P = Person("remlapmot", "U07L0L0SS6M")
+    TOM_W = Person("madwort", "U019R5FJ7G8")
 
     # Dict mapping github_username to People, constructed lazily and cached the
     # first time it's needed. Can't be built in the class definition as we

--- a/workspace/utils/people.py
+++ b/workspace/utils/people.py
@@ -1,10 +1,14 @@
-from collections import namedtuple
+from dataclasses import dataclass
 
 
-class Person(
-    namedtuple("Person", ["human_readable", "github_username", "slack_username"])
-):
-    def get_formatted_slack_username(self) -> str:
+@dataclass
+class Person:
+    human_readable: str
+    github_username: str
+    slack_username: str
+
+    @property
+    def formatted_slack_username(self) -> str:
         return f"<@{self.slack_username}>"
 
 

--- a/workspace/utils/people.py
+++ b/workspace/utils/people.py
@@ -15,7 +15,8 @@ class Person:
 class People:
     """Tech team members' GitHub and Slack usernames."""
 
-    # Find a Slack user's username by right-clicking on their name in the Slack app and clicking "Copy link".
+    # Find a Slack user's username by right-clicking on their name in the Slack
+    # app and clicking "Copy link".
 
     ALICE = Person("Alice", "alarthast", "U07KX6L3CMA")
     BECKY = Person("Becky", "rebkwok", "U01SP5JLBFD")

--- a/workspace/utils/people.py
+++ b/workspace/utils/people.py
@@ -2,7 +2,11 @@ from collections import namedtuple
 from enum import Enum
 
 
-Person = namedtuple("Person", ["human_readable", "github_username", "slack_username"])
+class Person(
+    namedtuple("Person", ["human_readable", "github_username", "slack_username"])
+):
+    def get_formatted_slack_username(self) -> str:
+        return f"<@{self.slack_username}>"
 
 
 class People(Enum):
@@ -54,7 +58,3 @@ def get_person_from_github_username(github_username) -> Person:
         slack_username=github_username,
     )
     return PEOPLE_BY_GITHUB_USERNAME.get(github_username, default)
-
-
-def get_formatted_slack_username(person: Person) -> str:
-    return f"<@{person.slack_username}>"

--- a/workspace/utils/people.py
+++ b/workspace/utils/people.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 from enum import Enum
 
 
-Person = namedtuple("Person", ["github_username", "slack_username"])
+Person = namedtuple("Person", ["human_readable", "github_username", "slack_username"])
 
 
 class People(Enum):
@@ -10,27 +10,27 @@ class People(Enum):
 
     # Find a Slack user's username by right-clicking on their name in the Slack app and clicking "Copy link".
 
-    ALICE = Person("alarthast", "U07KX6L3CMA")
-    BECKY = Person("rebkwok", "U01SP5JLBFD")
-    BEN_BC = Person("benbc", "U01SPCP06Q1")
-    CATHERINE = Person("CLStables", "U036A6LTR7D")
-    DAVE = Person("evansd", "UAXE5V4RG")
-    ELI = Person("eli-miriam", "U07LHEJ9TS4")
-    IAIN = Person("iaindillingham", "U01S6BLGK28")
-    JON = Person("Jongmassey", "U023ZG5H24R")
-    KATIE = Person("KatieB5", "U07KUKWBGKV")
-    LUCY = Person("lucyb", "U035FT48KEK")
-    MARY = Person("Mary-Anya", "U07LKQ06Q8L")
-    MILAN = Person("milanwiedemann", "U02GPV8NNU9")
-    MIKE = Person("mikerkelly", "U07KKL4PJJY")
-    PETER = Person("inglesp", "U4N1YPAP7")
-    PROVIDENCE = Person("Providence-o", "U07AGDM6ZJN")
-    RICHARD = Person("rw251", "U07QEMHUUMD")
-    SIMON = Person("bloodearnest", "U01AMBZUT47")
-    STEVE = Person("StevenMaude", "U01TJP3CG76")
-    THOMAS = Person("tomodwyer", "U01UQ0T2M7V")
-    TOM_P = Person("remlapmot", "U07L0L0SS6M")
-    TOM_W = Person("madwort", "U019R5FJ7G8")
+    ALICE = Person("Alice", "alarthast", "U07KX6L3CMA")
+    BECKY = Person("Becky", "rebkwok", "U01SP5JLBFD")
+    BEN_BC = Person("Ben BC", "benbc", "U01SPCP06Q1")
+    CATHERINE = Person("Catherine", "CLStables", "U036A6LTR7D")
+    DAVE = Person("Dave", "evansd", "UAXE5V4RG")
+    ELI = Person("Eli", "eli-miriam", "U07LHEJ9TS4")
+    IAIN = Person("Iain", "iaindillingham", "U01S6BLGK28")
+    JON = Person("Jon", "Jongmassey", "U023ZG5H24R")
+    KATIE = Person("Katie", "KatieB5", "U07KUKWBGKV")
+    LUCY = Person("Lucy", "lucyb", "U035FT48KEK")
+    MARY = Person("Mary", "Mary-Anya", "U07LKQ06Q8L")
+    MILAN = Person("Milan", "milanwiedemann", "U02GPV8NNU9")
+    MIKE = Person("Mike", "mikerkelly", "U07KKL4PJJY")
+    PETER = Person("Peter", "inglesp", "U4N1YPAP7")
+    PROVIDENCE = Person("Providence", "Providence-o", "U07AGDM6ZJN")
+    RICHARD = Person("Richard", "rw251", "U07QEMHUUMD")
+    SIMON = Person("Simon", "bloodearnest", "U01AMBZUT47")
+    STEVE = Person("Steve", "StevenMaude", "U01TJP3CG76")
+    THOMAS = Person("Thomas", "tomodwyer", "U01UQ0T2M7V")
+    TOM_P = Person("Tom P", "remlapmot", "U07L0L0SS6M")
+    TOM_W = Person("Tom W", "madwort", "U019R5FJ7G8")
 
 
 PEOPLE_BY_GITHUB_USERNAME = {
@@ -48,7 +48,11 @@ TEAM_REX = [
 
 
 def get_person_from_github_username(github_username) -> Person:
-    default = Person(github_username=github_username, slack_username=github_username)
+    default = Person(
+        human_readable=github_username,
+        github_username=github_username,
+        slack_username=github_username,
+    )
     return PEOPLE_BY_GITHUB_USERNAME.get(github_username, default)
 
 


### PR DESCRIPTION
Fixes #695.

This uses the new people-related data structures and allows users to be named by Slack username in the `standup daily monday` repo, @-ing them in Slack. I tested this in the test Slack workspace (temporarily changing my own slack username locally as the username string is different per workspace apparently).

I don't think the `DependabotRotaReporter` class is suitable for this report as that cycles through a list of candidates and reports one of them each week, whereas the standup rota reports 6 people in a certain order each week, with the ordering alternating between "even" and "odd" weeks.

Also some changes to the class and test design that are hopefully beneficial, see individual commit messages.