### PR TITLE
Tidy up workflows commands

### DIFF
--- a/bennettbot/job_configs.py
+++ b/bennettbot/job_configs.py
@@ -303,13 +303,18 @@ raw_config = {
         "restricted": True,
         "description": "Report GitHub Actions workflow runs",
         "jobs": {
-            "check_links": {
-                "run_args_template": "python jobs.py custom --job-name check-links",
+            "show_group": {
+                "run_args_template": "python jobs.py show --group {group}",
                 "report_stdout": True,
                 "report_format": "blocks",
             },
             "display_emoji_key": {
                 "run_args_template": "python jobs.py key",
+                "report_stdout": True,
+                "report_format": "blocks",
+            },
+            "show": {
+                "run_args_template": "python jobs.py show --target {target}",
                 "report_stdout": True,
                 "report_format": "blocks",
             },
@@ -323,18 +328,13 @@ raw_config = {
                 "report_stdout": True,
                 "report_format": "blocks",
             },
-            "show": {
-                "run_args_template": "python jobs.py show --target {target}",
-                "report_stdout": True,
-                "report_format": "blocks",
-            },
         },
         "slack": [
             {
-                "command": "check-links",
-                "help": "Summarise GitHub Actions workflow runs for link-checking workflows in website repos.",
+                "command": "show-group",
+                "help": "Summarise GitHub Actions workflow runs for a custom defined group of workflows.",
                 "action": "schedule_job",
-                "job_type": "check_links",
+                "job_type": "show_group",
             },
             {
                 "command": "key",

--- a/bennettbot/job_configs.py
+++ b/bennettbot/job_configs.py
@@ -303,15 +303,14 @@ raw_config = {
         "restricted": True,
         "description": "Report GitHub Actions workflow runs",
         "jobs": {
-            "show_group": {
-                "run_args_template": "python jobs.py show --group {group}",
-                "report_stdout": True,
-                "report_format": "blocks",
-            },
             "display_emoji_key": {
                 "run_args_template": "python jobs.py key",
                 "report_stdout": True,
                 "report_format": "blocks",
+            },
+            "display_usage": {
+                "run_args_template": "python jobs.py usage",
+                "report_stdout": True,
             },
             "show": {
                 "run_args_template": "python jobs.py show --target {target}",
@@ -319,23 +318,27 @@ raw_config = {
                 "report_format": "blocks",
             },
             "show_all": {
-                "run_args_template": "python jobs.py show --target all",
+                "run_args_template": "python jobs.py show",
                 "report_stdout": True,
                 "report_format": "blocks",
             },
             "show_failed": {
-                "run_args_template": "python jobs.py show --target all --skip-successful",
+                "run_args_template": "python jobs.py show --target {target} --skip-successful",
+                "report_stdout": True,
+                "report_format": "blocks",
+            },
+            "show_failed_all": {
+                "run_args_template": "python jobs.py show --skip-successful",
+                "report_stdout": True,
+                "report_format": "blocks",
+            },
+            "show_group": {
+                "run_args_template": "python jobs.py show --group {group}",
                 "report_stdout": True,
                 "report_format": "blocks",
             },
         },
         "slack": [
-            {
-                "command": "show-group",
-                "help": "Summarise GitHub Actions workflow runs for a custom defined group of workflows.",
-                "action": "schedule_job",
-                "job_type": "show_group",
-            },
             {
                 "command": "key",
                 "help": "Show the emoji key being used in the workflow summaries.",
@@ -343,25 +346,41 @@ raw_config = {
                 "job_type": "display_emoji_key",
             },
             {
-                "command": "show all",
+                "command": "usage",
+                "help": "Show help message for the `show [target]` and `show-failed [target]` commands.",
+                "action": "schedule_job",
+                "job_type": "display_usage",
+            },
+            {
+                "command": "show",
                 "help": "Summarise GitHub Actions workflow runs for repos in all organisations.",
                 "action": "schedule_job",
                 "job_type": "show_all",
             },
             {
                 "command": "show-failed",
-                "help": "Summarise GitHub Actions workflow runs for repos in all organisations, skipping repos whose runs are all successful.",
+                "help": "Summarise unsuccessful GitHub Actions workflow runs for repos in all organisations.",
+                "action": "schedule_job",
+                "job_type": "show_failed_all",
+            },
+            {
+                "command": "show [target]",
+                "help": "Summarise GitHub Actions workflow runs for `target`. See `workflows usage` for valid `target` values.",
+                "action": "schedule_job",
+                "job_type": "show",
+            },
+            {
+                "command": "show-failed [target]",
+                "help": "Same as `show [target]`, but skips summarising repos whose runs are all successful.",
                 "action": "schedule_job",
                 "job_type": "show_failed",
             },
             {
-                "command": "show [target]",
-                # There is a line break in this help message because it will take two lines anyway and breaking here gives better readability.
-                "help": "Summarise GitHub Actions workflow runs for a given `target` organisation or repo, provided in the form of `org` or `org/repo`. \n(Note: `org` is limited to the following shorthands and their full names: `os (opensafely)`, `osc (opensafely-core)`, `bo (bennettoxford)`, `ebm (ebmdatalab)`.)",
+                "command": "show-group",
+                "help": "Summarise GitHub Actions workflow runs for a custom defined group of workflows.",
                 "action": "schedule_job",
-                "job_type": "show",
+                "job_type": "show_group",
             },
-
         ]
     },
     "techsupport": {

--- a/tests/workspace/test_workflows.py
+++ b/tests/workspace/test_workflows.py
@@ -183,9 +183,19 @@ def test_print_key():
     assert json.loads(jobs.get_text_blocks_for_key(None)) == blocks
 
 
+def test_print_usage():
+    usage_text = jobs.get_usage_text(None)
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(usage_text)
+    assert usage_text.startswith(
+        "Usage for `show [target]`. The behaviour for `show-failed [target]` is the same, but skips repos whose workflows are all successful."
+    )
+
+
 @pytest.mark.parametrize("command", ["show", "show --target all"])
 def test_all_as_target(command):
     args = jobs.get_command_line_parser().parse_args(command.split())
+    args = jobs.get_command_line_parser().parse_args("show --target all".split())
 
     with patch("workspace.workflows.jobs.summarise_all") as mock_summarise_all:
         jobs.main(args)
@@ -834,14 +844,7 @@ def test_main_show_invalid_target():
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": "Argument must be a known organisation or repo, or a repo given as [org/repo].",
-            },
-        },
-        {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": "Run `@test_username workflows help` to see the available organisations.",
+                "text": "Run `@test_username workflows usage` to see the valid values for `target`.",
             },
         },
     ]

--- a/tests/workspace/test_workflows.py
+++ b/tests/workspace/test_workflows.py
@@ -188,7 +188,7 @@ def test_print_usage():
     with pytest.raises(json.JSONDecodeError):
         json.loads(usage_text)
     assert usage_text.startswith(
-        "Usage for `show [target]`. The behaviour for `show-failed [target]` is the same, but skips repos whose workflows are all successful."
+        "Usage for `show [target]` (The behaviour for `show-failed [target]` is the same, but skips repos whose workflows are all successful):"
     )
 
 

--- a/tests/workspace/test_workflows.py
+++ b/tests/workspace/test_workflows.py
@@ -28,6 +28,19 @@ CACHE = {
         "conclusions": {str(key): "success" for key in WORKFLOWS_MAIN.keys()},
     }
 }
+RESULT_PATCH_SETTINGS = {
+    "org": "opensafely-core",
+    "repo": "airlock",
+    "team": "Team RAP",
+    "conclusions": ["success"] * 5,
+}
+RESULT_BLOCK = {
+    "type": "section",
+    "text": {
+        "type": "mrkdwn",
+        "text": f"<https://github.com/opensafely-core/airlock/actions?query=branch%3Amain|opensafely-core/airlock>: {':large_green_circle:' * 5}",
+    },
+}
 
 
 @pytest.fixture
@@ -461,12 +474,7 @@ def test_main_show_repo(mock_conclusions, conclusion, reported, emoji):
 
 @use_mock_results(
     [
-        {
-            "org": "opensafely-core",
-            "repo": "airlock",
-            "team": "Team RAP",
-            "conclusions": ["success"] * 5,
-        },
+        RESULT_PATCH_SETTINGS,
         {
             "org": "opensafely-core",
             "repo": "failing-repo",
@@ -496,24 +504,13 @@ def test_main_show_org():
                 "text": f"<https://github.com/opensafely-core/failing-repo/actions?query=branch%3Amain|opensafely-core/failing-repo>: {':red_circle:' * 5}",
             },
         },
-        {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": f"<https://github.com/opensafely-core/airlock/actions?query=branch%3Amain|opensafely-core/airlock>: {':large_green_circle:' * 5}",
-            },
-        },
+        RESULT_BLOCK,
     ]
 
 
 @use_mock_results(
     [
-        {
-            "org": "opensafely-core",
-            "repo": "airlock",
-            "team": "Team RAP",
-            "conclusions": ["success"] * 5,
-        },
+        RESULT_PATCH_SETTINGS,
         {
             "org": "opensafely",
             "repo": "documentation",
@@ -548,13 +545,7 @@ def test_main_show_all():
                 "text": "Workflows for Team RAP",
             },
         },
-        {
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": f"<https://github.com/opensafely-core/airlock/actions?query=branch%3Amain|opensafely-core/airlock>: {':large_green_circle:' * 5}",
-            },
-        },
+        RESULT_BLOCK,
     ]
 
 
@@ -566,12 +557,7 @@ def test_main_show_all():
 )
 @use_mock_results(
     [
-        {
-            "org": "opensafely-core",
-            "repo": "airlock",
-            "team": "Team RAP",
-            "conclusions": ["success"] * 5,
-        },
+        RESULT_PATCH_SETTINGS,
         {
             "org": "opensafely",
             "repo": "failing-repo",
@@ -586,31 +572,20 @@ def test_main_show_all_skip_failures():
     args = jobs.get_command_line_parser().parse_args("show".split())
     blocks = json.loads(jobs.main(args))
     assert blocks == [
-        {
+        {  # Only the Team RAP section should appear
             "type": "header",
             "text": {
                 "type": "plain_text",
                 "text": "Workflows for Team RAP",
             },
         },
-        {  # Only the Team RAP section should appear
-            "type": "section",
-            "text": {
-                "type": "mrkdwn",
-                "text": f"<https://github.com/opensafely-core/airlock/actions?query=branch%3Amain|opensafely-core/airlock>: {':large_green_circle:' * 5}",
-            },
-        },
+        RESULT_BLOCK,
     ]
 
 
 @use_mock_results(
     [
-        {
-            "org": "opensafely-core",
-            "repo": "airlock",
-            "team": "Team RAP",
-            "conclusions": ["success"] * 5,
-        },
+        RESULT_PATCH_SETTINGS,
         {
             "org": "opensafely",
             "repo": "documentation",
@@ -637,12 +612,7 @@ def test_main_show_failed_empty():
 
 @use_mock_results(
     [
-        {
-            "org": "opensafely-core",
-            "repo": "airlock",
-            "team": "Team RAP",
-            "conclusions": ["success"] * 5,
-        },
+        RESULT_PATCH_SETTINGS,
         {
             "org": "opensafely",
             "repo": "failing-repo",

--- a/workspace/workflows/config.py
+++ b/workspace/workflows/config.py
@@ -148,7 +148,7 @@ WORKFLOWS_KNOWN_TO_FAIL = {
     ],
 }
 
-CUSTOM_JOBS = {
+CUSTOM_WORKFLOWS_GROUPS = {
     "check-links": {
         "header_text": "Link-checking workflows",
         "workflows": {

--- a/workspace/workflows/jobs.py
+++ b/workspace/workflows/jobs.py
@@ -331,7 +331,7 @@ def main(args) -> str:
 
 def _main(targets: list[str], skip_successful: bool) -> str:
     """
-    Main function to report on the status of workflows in a specified target.
+    Main function to report on the status of workflows in one or more specified targets.
     args:
         targets: list[str]
             List elements may be one of the following:
@@ -396,16 +396,21 @@ def get_text_blocks_for_key(args) -> str:
 
 
 def get_usage_text(args) -> str:
+    orgs = ", ".join([f"`{k} ({v})`" for k, v in config.SHORTHANDS.items()])
     return "\n".join(
         [
-            "Usage for `show [target]`. The behaviour for `show-failed [target]` is the same, but skips repos whose workflows are all successful.",
+            "Usage for `show [target]` (The behaviour for `show-failed [target]` is the same, but skips repos whose workflows are all successful):",
             "`show [all]`: Summarise all repos, sectioned by team.",
-            "`show [org]`: Summarise all repos for a known organisation, which is limited to the following shorthands and their full names: `os (opensafely)`, `osc (opensafely-core)` or `ebm (ebmdatalab)`.",
+            f"`show [org]`: Summarise all repos for a known organisation, which is limited to the following shorthands and their full names: {orgs}.",
             "`show [repo]`: Report status for all workflows in a known repo (e.g. `show airlock`) or a repo in a known org (e.g. `show os/some-study-repo`).",
             "To pass multiple targets, separate them by spaces (e.g. `show os osc` or `show airlock ehrql`).",
+            "When passing multiple targets, the targets should be of the same type (multiple orgs or multiple repos, but not a combination of both).",
             "",
             "List of known repos:",
             ", ".join(config.REPOS.keys()),
+            "",
+            "Usage for `show-group`:",
+            f"`show-group [group]`: Summarise a custom group of workflows. Available groups are: {', '.join(config.CUSTOM_WORKFLOWS_GROUPS.keys())}.",
         ]
     )
 

--- a/workspace/workflows/jobs.py
+++ b/workspace/workflows/jobs.py
@@ -45,10 +45,7 @@ def get_locations_for_org(org: str) -> list[str]:
 def report_invalid_target(target) -> str:
     blocks = get_basic_header_and_text_blocks(
         header_text=f"{target} was not recognised",
-        texts=[
-            "Argument must be a known organisation or repo, or a repo given as [org/repo].",
-            f"Run `@{settings.SLACK_APP_USERNAME} workflows help` to see the available organisations.",
-        ],
+        texts=f"Run `@{settings.SLACK_APP_USERNAME} workflows usage` to see the valid values for `target`.",
     )
     return json.dumps(blocks)
 
@@ -398,6 +395,21 @@ def get_text_blocks_for_key(args) -> str:
     return json.dumps(blocks)
 
 
+def get_usage_text(args) -> str:
+    return "\n".join(
+        [
+            "Usage for `show [target]`. The behaviour for `show-failed [target]` is the same, but skips repos whose workflows are all successful.",
+            "`show [all]`: Summarise all repos, sectioned by team.",
+            "`show [org]`: Summarise all repos for a known organisation, which is limited to the following shorthands and their full names: `os (opensafely)`, `osc (opensafely-core)` or `ebm (ebmdatalab)`.",
+            "`show [repo]`: Report status for all workflows in a known repo (e.g. `show airlock`) or a repo in a known org (e.g. `show os/some-study-repo`).",
+            "To pass multiple targets, separate them by spaces (e.g. `show os osc` or `show airlock ehrql`).",
+            "",
+            "List of known repos:",
+            ", ".join(config.REPOS.keys()),
+        ]
+    )
+
+
 def get_command_line_parser():
     class SplitString(argparse.Action):
         def __call__(self, parser, namespace, values, option_string=None):
@@ -417,6 +429,10 @@ def get_command_line_parser():
     # Display key
     key_parser = subparsers.add_parser("key")
     key_parser.set_defaults(func=get_text_blocks_for_key)
+
+    # Display usage
+    usage_text_parser = subparsers.add_parser("usage")
+    usage_text_parser.set_defaults(func=get_usage_text)
     return parser
 
 


### PR DESCRIPTION
Addresses #610, albeit not in the exact way described in the ticket, and brings additional changes. 

#610 wanted to add a `show-multiple` job: This is not done, instead the `show` command is now able to take a comma-separated list.

#610 also wanted to incorporate `check-links` into `show`: This has been done, but maybe slightly differently from what the ticket implied:
- While `show documentation,bennett.ox.ac.uk,opensafely.org,team-manual` is now a valid command, it will show all workflow statuses for all those repos. This results in more clutter than the current approach, so ...
- `show check-links` exactly replaces the existing `check-links` command, where only the specified workflow IDs (for link checking) are shown. I believe this is more suited to the use case and should be kept.

Additionally, this PR changes the main slack commands from the trio of `show all`, `show [target]` and `show-failed` to the more-structured 2x2 grid of: 
- `show` (shorthand for `show all`), 
- `show-failed` (shorthand for `show-failed all`), 
- `show [target]` and 
- `show-failed [target]`. 

This change gets rid of the ugliness of `show all` being two words separated by a space and `show-failed` being hyphenated. The thinking is that we would not want to introduce additional inconvenience of needing a user to type `show-failed all`, so let's just omit the need to type `all` to `show all`.
The `show-failed [target]` command hopefully adds flexibility, especially now that a list of repos can be passed as the target.

Since the description for what a user may pass as a `target` has increased and became difficult to fit into the help message, a `workflows usage` command is added to show this description. I would have preferred to have it as something like `workflows show help` to be more in line with the general `help` command, but this would mean having to pass the help text as a block and not plain text. I've found that the arbitrary line-breaking that Slack does for blocks makes the text less readable, so I've stuck with `workflows usage`.

The code restructuring in this PR should make doing #618 easier.