### PR TITLE
Simplify the  `show --target` parser argument

### DIFF
--- a/bennettbot/job_configs.py
+++ b/bennettbot/job_configs.py
@@ -376,7 +376,7 @@ raw_config = {
                 "job_type": "show_failed",
             },
             {
-                "command": "show-group",
+                "command": "show-group [group]",
                 "help": "Summarise GitHub Actions workflow runs for a custom defined group of workflows.",
                 "action": "schedule_job",
                 "job_type": "show_group",

--- a/tests/workspace/test_workflows.py
+++ b/tests/workspace/test_workflows.py
@@ -240,8 +240,16 @@ def test_website_repo_as_target():
         MockReporter.assert_called_once_with("ebmdatalab/bennett.ox.ac.uk")
 
 
-def test_list_of_orgs_as_target():
-    args = jobs.get_command_line_parser().parse_args(["show", "--target", "osc ebm"])
+@pytest.mark.parametrize(
+    "cli_args",
+    [
+        ["show", "--target", "osc ebm"],
+        ["show", "--target", "osc  ebm"],
+        ["show", "--target", " osc ebm"],
+    ],
+)
+def test_list_of_orgs_as_target(cli_args):
+    args = jobs.get_command_line_parser().parse_args(cli_args)
     with patch("workspace.workflows.jobs.summarise_org") as mock_summarise_org:
         jobs.main(args)
         mock_summarise_org.assert_any_call("opensafely-core", False)

--- a/workspace/workflows/jobs.py
+++ b/workspace/workflows/jobs.py
@@ -418,15 +418,19 @@ def get_usage_text(args) -> str:
 def get_command_line_parser():
     class SplitString(argparse.Action):
         def __call__(self, parser, namespace, values, option_string=None):
-            # Split space-separated strings into individual list items
-            setattr(namespace, self.dest, " ".join(values).split(" "))
+            setattr(namespace, self.dest, values.split())
 
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(required=True)
 
     # Main task: show workflows
     show_parser = subparsers.add_parser("show")
-    show_parser.add_argument("--target", nargs="+", default=["all"], action=SplitString)
+    show_parser.add_argument(
+        "--target",
+        default="all",
+        action=SplitString,
+        help="Provide multiple targets as a space-separated quoted string, e.g. 'os osc'.",
+    )
     show_parser.add_argument("--group", required=False)
     show_parser.add_argument("--skip-successful", action="store_true", default=False)
     show_parser.set_defaults(func=main)


### PR DESCRIPTION
The bot is always going to run `python jobs.py show --target target` with `target` as a single string in quotes.
i.e. it will always be running `python jobs.py show --target 'os osc'` and never `python jobs.py show --target os osc`.

Given that it is unlikely for anyone other than the bot to be running the command, there is not really any need to support the latter scenario, so the code can be simplified. 