### PR TITLE
Dependabot Slack repo: add combined link

### DIFF
--- a/tests/workspace/test_dependabot_rota.py
+++ b/tests/workspace/test_dependabot_rota.py
@@ -6,7 +6,16 @@ from workspace.utils.people import People
 
 TEAM_REX = [People.JON, People.LUCY, People.KATIE]
 
-EXTRA_TEXT = "\nReview <https://github.com/opensafely-core/job-server/pulls|job-server>, <https://github.com/opensafely-core/opencodelists/pulls|opencodelists>, <https://github.com/ebmdatalab/metrics/pulls|metrics>, <https://github.com/opensafely-core/reports/pulls|reports>, <https://github.com/opensafely-core/actions-registry/pulls|actions-registry> and <https://github.com/opensafely-core/research-template-docker/pulls|research-template-docker> repos and merge any outstanding non-NPM Dependabot/update-dependencies-action PRs.\nReview Thomas' PRs for NPM updates.\n"
+EXTRA_TEXT = (
+    "\nReview <https://github.com/opensafely-core/job-server/pulls|job-server>, "
+    "<https://github.com/opensafely-core/opencodelists/pulls|opencodelists>, "
+    "<https://github.com/ebmdatalab/metrics/pulls|metrics>, "
+    "<https://github.com/opensafely-core/reports/pulls|reports>, "
+    "<https://github.com/opensafely-core/actions-registry/pulls|actions-registry> "
+    "and <https://github.com/opensafely-core/research-template-docker/pulls|research-template-docker> "
+    "repos and merge any outstanding non-NPM Dependabot/update-dependencies-action PRs."
+    "\nReview Thomas' PRs for NPM updates.\n"
+)
 
 
 def test_rota_report_on_monday(freezer, monkeypatch):

--- a/tests/workspace/test_dependabot_rota.py
+++ b/tests/workspace/test_dependabot_rota.py
@@ -6,6 +6,8 @@ from workspace.utils.people import People
 
 TEAM_REX = [People.JON, People.LUCY, People.KATIE]
 
+EXTRA_TEXT = "\nReview <https://github.com/opensafely-core/job-server/pulls|job-server>, <https://github.com/opensafely-core/opencodelists/pulls|opencodelists>, <https://github.com/ebmdatalab/metrics/pulls|metrics>, <https://github.com/opensafely-core/reports/pulls|reports>, <https://github.com/opensafely-core/actions-registry/pulls|actions-registry> and <https://github.com/opensafely-core/research-template-docker/pulls|research-template-docker> repos and merge any outstanding non-NPM Dependabot/update-dependencies-action PRs.\nReview Thomas' PRs for NPM updates.\n"
+
 
 def test_rota_report_on_monday(freezer, monkeypatch):
     freezer.move_to("2024-03-25")
@@ -31,7 +33,7 @@ def test_rota_report_on_monday(freezer, monkeypatch):
         },
         {
             "text": {
-                "text": "\nReview <https://github.com/opensafely-core/job-server/pulls|job-server>, <https://github.com/opensafely-core/opencodelists/pulls|opencodelists>, <https://github.com/ebmdatalab/metrics/pulls|metrics>, <https://github.com/opensafely-core/reports/pulls|reports>, <https://github.com/opensafely-core/actions-registry/pulls|actions-registry> and <https://github.com/opensafely-core/research-template-docker/pulls|research-template-docker> repos and merge any outstanding non-NPM Dependabot/update-dependencies-action PRs.\nReview Thomas' PRs for NPM updates.\n",
+                "text": EXTRA_TEXT,
                 "type": "mrkdwn",
             },
             "type": "section",
@@ -63,7 +65,7 @@ def test_rota_report_on_tuesday(freezer, monkeypatch):
         },
         {
             "text": {
-                "text": "\nReview <https://github.com/opensafely-core/job-server/pulls|job-server>, <https://github.com/opensafely-core/opencodelists/pulls|opencodelists>, <https://github.com/ebmdatalab/metrics/pulls|metrics>, <https://github.com/opensafely-core/reports/pulls|reports>, <https://github.com/opensafely-core/actions-registry/pulls|actions-registry> and <https://github.com/opensafely-core/research-template-docker/pulls|research-template-docker> repos and merge any outstanding non-NPM Dependabot/update-dependencies-action PRs.\nReview Thomas' PRs for NPM updates.\n",
+                "text": EXTRA_TEXT,
                 "type": "mrkdwn",
             },
             "type": "section",

--- a/tests/workspace/test_dependabot_rota.py
+++ b/tests/workspace/test_dependabot_rota.py
@@ -7,13 +7,21 @@ from workspace.utils.people import People
 TEAM_REX = [People.JON, People.LUCY, People.KATIE]
 
 EXTRA_TEXT = (
-    "\nReview <https://github.com/opensafely-core/job-server/pulls|job-server>, "
+    "\nReview repos <https://github.com/opensafely-core/job-server/pulls|job-server>, "
     "<https://github.com/opensafely-core/opencodelists/pulls|opencodelists>, "
     "<https://github.com/ebmdatalab/metrics/pulls|metrics>, "
     "<https://github.com/opensafely-core/reports/pulls|reports>, "
     "<https://github.com/opensafely-core/actions-registry/pulls|actions-registry> "
-    "and <https://github.com/opensafely-core/research-template-docker/pulls|research-template-docker> "
-    "repos and merge any outstanding non-NPM Dependabot/update-dependencies-action PRs."
+    "and <https://github.com/opensafely-core/research-template-docker/pulls|research-template-docker>. "
+    "<https://github.com/pulls?q=is%3Apr+is%3Aopen+repo%3A"
+    "opensafely-core%2Fjob-server+"
+    "repo%3Aopensafely-core%2Fopencodelists+"
+    "repo%3Aebmdatalab%2Fmetrics+"
+    "repo%3Aopensafely-core%2Freports+"
+    "repo%3Aopensafely-core%2Factions-registry+"
+    "repo%3Aopensafely-core%2Fresearch-template-docker"
+    "|Combined link>. "
+    "Merge any outstanding non-NPM Dependabot/update-dependencies-action PRs."
     "\nReview Thomas' PRs for NPM updates.\n"
 )
 

--- a/workspace/dependabot/jobs.py
+++ b/workspace/dependabot/jobs.py
@@ -45,19 +45,25 @@ class DependabotRotaReporter(RotaReporter):
 
 
 def report_rota() -> str:
-    return DependabotRotaReporter(
-        title="Dependabot rota",
-    ).report(
-        "\nReview "
-        "<https://github.com/opensafely-core/job-server/pulls|job-server>, "
-        "<https://github.com/opensafely-core/opencodelists/pulls|opencodelists>, "
-        "<https://github.com/ebmdatalab/metrics/pulls|metrics>, "
-        "<https://github.com/opensafely-core/reports/pulls|reports>, "
-        "<https://github.com/opensafely-core/actions-registry/pulls|actions-registry> and "
-        "<https://github.com/opensafely-core/research-template-docker/pulls|research-template-docker> "
+    repos = [
+        ("opensafely-core", "job-server"),
+        ("opensafely-core", "opencodelists"),
+        ("ebmdatalab", "metrics"),
+        ("opensafely-core", "reports"),
+        ("opensafely-core", "actions-registry"),
+        ("opensafely-core", "research-template-docker"),
+    ]
+    repo_links = [
+        f"<https://github.com/{org}/{repo}/pulls|{repo}>" for org, repo in repos
+    ]
+    repo_links_text = ", ".join(repo_links[:-1]) + " and " + repo_links[-1]
+    extra_text = (
+        f"\nReview {repo_links_text} "
         "repos and merge any outstanding non-NPM Dependabot/update-dependencies-action PRs.\n"
         "Review Thomas' PRs for NPM updates.\n"
     )
+
+    return DependabotRotaReporter(title="Dependabot rota").report(extra_text)
 
 
 if __name__ == "__main__":

--- a/workspace/dependabot/jobs.py
+++ b/workspace/dependabot/jobs.py
@@ -56,10 +56,14 @@ def report_rota() -> str:
     repo_links = [
         f"<https://github.com/{org}/{repo}/pulls|{repo}>" for org, repo in repos
     ]
+    combined_link = "https://github.com/pulls?q=is%3Apr+is%3Aopen+" + "+".join(
+        f"repo%3A{org}%2F{repo}" for org, repo in repos
+    )
+
     repo_links_text = ", ".join(repo_links[:-1]) + " and " + repo_links[-1]
     extra_text = (
-        f"\nReview {repo_links_text} "
-        "repos and merge any outstanding non-NPM Dependabot/update-dependencies-action PRs.\n"
+        f"\nReview repos {repo_links_text}. <{combined_link}|Combined link>. "
+        "Merge any outstanding non-NPM Dependabot/update-dependencies-action PRs.\n"
         "Review Thomas' PRs for NPM updates.\n"
     )
 


### PR DESCRIPTION
A link to a [combined view on all our repos](https://github.com/pulls?q=is%3Apr+is%3Aopen+repo%3Aopensafely-core%2Fjob-server+repo%3Aopensafely-core%2Fopencodelists+repo%3Aebmdatalab%2Fmetrics+repo%3Aopensafely-core%2Freports+repo%3Aopensafely-core%2Factions-registry+repo%3Aopensafely-core%2Fresearch-template-docker) may be a useful way to identify PRs for review. This is in the Slack report workflow that we get each Monday telling us who's turn it is and what to do.