### PR TITLE
Rename SKIPPED_WORKFLOWS_ON_MAIN and ignore CodeQL in backend-server

### DIFF
--- a/workspace/workflows/config.py
+++ b/workspace/workflows/config.py
@@ -103,6 +103,9 @@ REPOS = {
 }
 
 IGNORED_WORKFLOWS = {
+    "opensafely-core/backend-server": [
+        88048790,  # Disabled
+    ],
     "opensafely/documentation": [
         65834242,  # [On workflow dispatch] Check docs with Vale
     ],

--- a/workspace/workflows/config.py
+++ b/workspace/workflows/config.py
@@ -102,7 +102,7 @@ REPOS = {
     },
 }
 
-SKIPPED_WORKFLOWS_ON_MAIN = {
+IGNORED_WORKFLOWS = {
     "opensafely/documentation": [
         65834242,  # [On workflow dispatch] Check docs with Vale
     ],

--- a/workspace/workflows/jobs.py
+++ b/workspace/workflows/jobs.py
@@ -121,11 +121,11 @@ class RepoWorkflowReporter:
     def get_workflows(self) -> dict:
         results = self._get_json_response("actions/workflows")["workflows"]
         workflows = {wf["id"]: wf["name"] for wf in results}
-        self.remove_workflows_skipped_on_main(workflows)
+        self.remove_ignored_workflows(workflows)
         return workflows
 
-    def remove_workflows_skipped_on_main(self, workflows):
-        skipped = config.SKIPPED_WORKFLOWS_ON_MAIN.get(self.location, [])
+    def remove_ignored_workflows(self, workflows):
+        skipped = config.IGNORED_WORKFLOWS.get(self.location, [])
         for workflow_id in skipped:
             workflows.pop(workflow_id, None)
 


### PR DESCRIPTION
[Slack conversation](https://bennettoxford.slack.com/archives/C63UXGB8E/p1739781342162469?thread_ts=1739273253.689819&cid=C63UXGB8E)

- The `SKIPPED_WORKFLOWS_ON_MAIN` dictionary can be used more generally to contain any workflows we would like to ignore (e.g. a disabled workflow). Rename it to better reflect its more broad purpose
- Ignore the disabled CodeQL workflow in backend-server (ID retrieved from https://api.github.com/repos/opensafely-core/backend-server/actions/workflows) 