### PR TITLE
Ignore runs if not in self.workflow_ids and add corresponding test

### DIFF
--- a/tests/test_job_configs.py
+++ b/tests/test_job_configs.py
@@ -71,7 +71,7 @@ def test_build_config():
     config = build_config(raw_config)
     # Assert that in tests, settings.WORKSPACE_DIR and
     # settings.WRITEABLE_WORKSPACE_DIR are different. Jobs that don't already have
-    # a namespace dir will useWRITEABLE_WORKSPACE_DIR
+    # a namespace dir will use WRITEABLE_WORKSPACE_DIR
     assert settings.WORKSPACE_DIR != settings.WRITEABLE_WORKSPACE_DIR
     assert config == {
         "jobs": {

--- a/tests/workspace/test_workflows.py
+++ b/tests/workspace/test_workflows.py
@@ -388,6 +388,16 @@ def test_all_workflows_found(mock_airlock_reporter, cache_path):
     assert "created" not in Mocket.last_request().querystring
 
 
+def test_some_workflows_ignored(mock_airlock_reporter, cache_path):
+    # Have the first run in runs.json be for an ignored workflow
+    mock_airlock_reporter.workflows.pop(113602598)
+    mock_airlock_reporter.workflow_ids = set(mock_airlock_reporter.workflows.keys())
+    with patch("workspace.workflows.jobs.CACHE_PATH", cache_path):
+        conclusions = mock_airlock_reporter.get_latest_conclusions()
+    assert len(conclusions) == len(WORKFLOWS_MAIN) - 1
+    assert 113602598 not in conclusions
+
+
 def test_some_workflows_not_found(mock_airlock_reporter, cache_path):
     mock_airlock_reporter.workflows[1234] = "Workflow that only exists in the cache"
     mock_airlock_reporter.cache = {

--- a/workspace/workflows/jobs.py
+++ b/workspace/workflows/jobs.py
@@ -211,8 +211,9 @@ class RepoWorkflowReporter:
         for run in all_runs:
             if run["workflow_id"] in found_ids:
                 continue
-            latest_runs.append(run)
-            found_ids.add(run["workflow_id"])
+            if run["workflow_id"] in self.workflow_ids:
+                latest_runs.append(run)
+                found_ids.add(run["workflow_id"])
             if found_ids == self.workflow_ids:
                 return latest_runs, set()
         missing_ids = self.workflow_ids - found_ids


### PR DESCRIPTION
After #710, we now have a general ignore list of workflow ids. 

- Add an `if` statement to handle the case where runs for an ignored workflow is found - "handle" here of course means "dropping it".

- Add a corresponding unit test