### PR TITLE
Add inbox rota report

### DIFF
--- a/bennettbot/job_configs.py
+++ b/bennettbot/job_configs.py
@@ -98,6 +98,24 @@ raw_config = {
             },
         ],
     },
+    "inbox": {
+        "description": "Email inbox tools",
+        "jobs": {
+            "rota_report": {
+                "run_args_template": "python jobs.py",
+                "report_stdout": True,
+                "report_format": "blocks",
+            },
+        },
+        "slack": [
+            {
+                "command": "rota report",
+                "help": "Report who's next on inbox checking duty",
+                "action": "schedule_job",
+                "job_type": "rota_report",
+            },
+        ],
+    },
     "op": {
         "restricted": True,
         "description": "OpenPrescribing deployment and tools",

--- a/tests/workspace/inbox-rota.csv
+++ b/tests/workspace/inbox-rota.csv
@@ -1,0 +1,13 @@
+Week commencing,Researcher,,,
+2025-03-10,PersonA,,,
+2025-03-17,PersonB,,,
+2025-03-24,PersonC,,"If you are away, please arrange a swap with someone else.",
+2025-03-31,PersonD,,,
+2025-04-07,PersonA,,,
+2025-04-14,PersonB,,,
+2025-04-21,PersonC,,,
+2025-04-28,PersonD,,,Total
+2025-05-05,PersonA,,PersonA,6
+2025-05-12,PersonB,,PersonB,6
+2025-05-19,PersonC,,PersonC,6
+2025-05-26,PersonD,,PersonD,6

--- a/tests/workspace/test_inbox_rota.py
+++ b/tests/workspace/test_inbox_rota.py
@@ -1,0 +1,110 @@
+import csv
+import json
+from unittest.mock import patch
+
+from workspace.inbox.jobs import report_rota
+
+
+@patch("workspace.inbox.jobs.InboxRotaReporter.get_rota_data_from_sheet")
+def test_rota_report_on_monday(get_rota_data_from_sheet, freezer):
+    freezer.move_to("2025-03-10")
+    with open("tests/workspace/inbox-rota.csv") as f:
+        get_rota_data_from_sheet.return_value = list(csv.reader(f))
+    blocks = json.loads(report_rota())
+    assert blocks == [
+        {
+            "text": {"text": "Inbox rota (team@opensafely.org)", "type": "plain_text"},
+            "type": "header",
+        },
+        {
+            "text": {
+                "text": "Researcher this week (10 Mar-14 Mar): PersonA",
+                "type": "mrkdwn",
+            },
+            "type": "section",
+        },
+        {
+            "text": {
+                "text": "Researcher next week (17 Mar-21 Mar): PersonB",
+                "type": "mrkdwn",
+            },
+            "type": "section",
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "<https://docs.google.com/spreadsheets/d/1Z50ektmaOV-H78sC__hmyH2l5HAmPsIslZYYUfT3UWU|Open rota spreadsheet>",
+            },
+        },
+    ]
+
+
+@patch("workspace.inbox.jobs.InboxRotaReporter.get_rota_data_from_sheet")
+def test_rota_report_on_tuesday(get_rota_data_from_sheet, freezer):
+    freezer.move_to("2025-03-11")
+    with open("tests/workspace/inbox-rota.csv") as f:
+        get_rota_data_from_sheet.return_value = list(csv.reader(f))
+    blocks = json.loads(report_rota())
+    assert blocks == [
+        {
+            "text": {"text": "Inbox rota (team@opensafely.org)", "type": "plain_text"},
+            "type": "header",
+        },
+        {
+            "text": {
+                "text": "Researcher this week (10 Mar-14 Mar): PersonA",
+                "type": "mrkdwn",
+            },
+            "type": "section",
+        },
+        {
+            "text": {
+                "text": "Researcher next week (17 Mar-21 Mar): PersonB",
+                "type": "mrkdwn",
+            },
+            "type": "section",
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "<https://docs.google.com/spreadsheets/d/1Z50ektmaOV-H78sC__hmyH2l5HAmPsIslZYYUfT3UWU|Open rota spreadsheet>",
+            },
+        },
+    ]
+
+
+@patch("workspace.inbox.jobs.InboxRotaReporter.get_rota_data_from_sheet")
+def test_rota_report_missing_future_dates(get_rota_data_from_sheet, freezer):
+    freezer.move_to("2026-01-08")
+    with open("tests/workspace/inbox-rota.csv") as f:
+        get_rota_data_from_sheet.return_value = list(csv.reader(f))
+    blocks = json.loads(report_rota())
+    assert blocks == [
+        {
+            "text": {"text": "Inbox rota (team@opensafely.org)", "type": "plain_text"},
+            "type": "header",
+        },
+        {
+            "text": {
+                "text": "No rota data found for this week",
+                "type": "mrkdwn",
+            },
+            "type": "section",
+        },
+        {
+            "text": {
+                "text": "No rota data found for next week",
+                "type": "mrkdwn",
+            },
+            "type": "section",
+        },
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": "<https://docs.google.com/spreadsheets/d/1Z50ektmaOV-H78sC__hmyH2l5HAmPsIslZYYUfT3UWU|Open rota spreadsheet>",
+            },
+        },
+    ]

--- a/workspace/inbox/jobs.py
+++ b/workspace/inbox/jobs.py
@@ -1,0 +1,27 @@
+from datetime import date
+
+from workspace.utils.rota import SpreadsheetRotaReporter
+
+
+class InboxRotaReporter(SpreadsheetRotaReporter):
+    def convert_rota_data_to_dictionary(self, rows) -> dict:
+        return {row[0]: row[1] for row in rows[1:] if len(row) >= 2}
+
+    def get_rota_text_for_week(self, rota: dict, monday: date, this_or_next: str):
+        try:
+            researcher = rota[str(monday)]
+            return f"Researcher {this_or_next} week ({self.format_week(monday)}): {researcher}"
+        except KeyError:
+            return f"No rota data found for {this_or_next} week"
+
+
+def report_rota():
+    return InboxRotaReporter(
+        title="Inbox rota (team@opensafely.org)",
+        spreadsheet_id="1Z50ektmaOV-H78sC__hmyH2l5HAmPsIslZYYUfT3UWU",
+        sheet_range="Rota 2025",
+    ).report()
+
+
+if __name__ == "__main__":
+    print(report_rota())


### PR DESCRIPTION
Add a workspace to report the team inbox rota.

At the moment there is only one email address (team@opensafely.org) that has such a rota, so there is only one job (report_rota). If there are more inbox rotas in the future, some renaming/refactoring will be needed.