### PR TITLE
Parse Github project board statuses as a comma separated string

### DIFF
--- a/bennettbot/job_configs.py
+++ b/bennettbot/job_configs.py
@@ -286,12 +286,12 @@ raw_config = {
                 "report_format": "blocks",
             },
             "run_rap_report": {
-                "run_args_template": "python generate_report.py --project-num 15 --statuses 'Under Review' 'Blocked' 'In Progress'",
+                "run_args_template": "python generate_report.py --project-num 15 --statuses 'Under Review,Blocked,In Progress'",
                 "report_stdout": True,
                 "report_format": "blocks",
             },
             "run_rex_report": {
-                "run_args_template": "python generate_report.py --project-num 14 --statuses 'In Progress' 'In Review' 'Blocked'",
+                "run_args_template": "python generate_report.py --project-num 14 --statuses 'In Progress,In Review,Blocked'",
                 "report_stdout": True,
                 "report_format": "blocks",
             },

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,6 @@
+import argparse
+
+from workspace.utils.argparse import SplitString
 from workspace.utils.blocks import truncate_text
 
 
@@ -6,3 +9,14 @@ def test_truncate_text():
     truncated_text = truncate_text(original_text)
     assert len(truncated_text) == 3000
     assert truncated_text.endswith("...")
+
+
+def test_split_string():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--values",
+        action=SplitString,
+        help="A space-separated quoted string",
+    )
+    args = parser.parse_args(["--values", "value1 value2 value3"])
+    assert args.values == ["value1", "value2", "value3"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import argparse
 
-from workspace.utils.argparse import SplitString
+from workspace.utils.argparse import SplitCommaSeparatedString, SplitString
 from workspace.utils.blocks import truncate_text
 
 
@@ -19,4 +19,15 @@ def test_split_string():
         help="A space-separated quoted string",
     )
     args = parser.parse_args(["--values", "value1 value2 value3"])
+    assert args.values == ["value1", "value2", "value3"]
+
+
+def test_split_comma_separated_string():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--values",
+        action=SplitCommaSeparatedString,
+        help="A comma-separated list of values",
+    )
+    args = parser.parse_args(["--values", "value1, value2,value3"])
     assert args.values == ["value1", "value2", "value3"]

--- a/workspace/report/generate_report.py
+++ b/workspace/report/generate_report.py
@@ -4,6 +4,7 @@ import os
 
 import requests
 
+from workspace.utils.argparse import SplitCommaSeparatedString
 from workspace.utils.blocks import get_basic_header_and_text_blocks
 from workspace.utils.people import People
 
@@ -189,6 +190,11 @@ def get_status_and_summary(card):  # pragma: no cover
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--project-num", help="The GitHub Project number", type=int)
-    parser.add_argument("--statuses", nargs="+", help="List of GitHub Project statuses")
+    parser.add_argument(
+        "--statuses",
+        type=str,
+        action=SplitCommaSeparatedString,
+        help="List of GitHub Project statuses",
+    )
     args = parser.parse_args()
     print(main(args.project_num, args.statuses))

--- a/workspace/utils/argparse.py
+++ b/workspace/utils/argparse.py
@@ -4,3 +4,8 @@ import argparse
 class SplitString(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         setattr(namespace, self.dest, values.split())
+
+
+class SplitCommaSeparatedString(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, [v.strip() for v in values.split(",")])

--- a/workspace/utils/argparse.py
+++ b/workspace/utils/argparse.py
@@ -1,0 +1,6 @@
+import argparse
+
+
+class SplitString(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, values.split())

--- a/workspace/workflows/jobs.py
+++ b/workspace/workflows/jobs.py
@@ -7,6 +7,7 @@ from urllib.parse import urljoin
 import requests
 
 from bennettbot import settings
+from workspace.utils.argparse import SplitString
 from workspace.utils.blocks import (
     get_basic_header_and_text_blocks,
     get_header_block,
@@ -417,10 +418,6 @@ def get_usage_text(args) -> str:
 
 
 def get_command_line_parser():
-    class SplitString(argparse.Action):
-        def __call__(self, parser, namespace, values, option_string=None):
-            setattr(namespace, self.dest, values.split())
-
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(required=True)
 


### PR DESCRIPTION
The `report board` command asks to pass multiple statuses as a comma separated string in the Slack message.

It appears that there is no code to parse and split the comma separated string, maybe it has been lost in previous changes.
(Re-)implement this using an `argparse.Action`.

Testing:
![image](https://github.com/user-attachments/assets/c1a42bb5-753a-4b45-b954-f274b7fdf311)

The `report teamrex` and `report teamrap` commands have also been tested.