### PR TITLE
Require `org` parameter in `report board` command

### DIFF
--- a/bennettbot/job_configs.py
+++ b/bennettbot/job_configs.py
@@ -278,10 +278,11 @@ raw_config = {
         ],
     },
     "report": {
+        "restricted": True,
         "description": "Run GitHub Project board reports",
         "jobs": {
             "run_report": {
-                "run_args_template": "python generate_report.py --project-num {project_number} --statuses {statuses}",
+                "run_args_template": "python generate_report.py --project-num {project_number} --statuses {statuses} --org {org}",
                 "report_stdout": True,
                 "report_format": "blocks",
             },
@@ -298,7 +299,7 @@ raw_config = {
         },
         "slack": [
             {
-                "command": "board [project_number] [statuses]",
+                "command": "board [org] [project_number] [statuses]",
                 "help": "Report GitHub project board. Provide multiple statuses separated by commas.",
                 "action": "schedule_job",
                 "job_type": "run_report",

--- a/workspace/report/generate_report.py
+++ b/workspace/report/generate_report.py
@@ -7,6 +7,7 @@ import requests
 from workspace.utils.argparse import SplitCommaSeparatedString
 from workspace.utils.blocks import get_basic_header_and_text_blocks
 from workspace.utils.people import People
+from workspace.utils.shorthands import ORGS
 
 
 URL = "https://api.github.com/graphql"
@@ -27,6 +28,7 @@ def post_request(payload):  # pragma: no cover
 
 
 def main(project_num, statuses, org=ORG_NAME):
+    org = ORGS.get(org, org)
     project_id = get_project_id(int(project_num), org)
     cards = get_project_cards(project_id, org)
     tickets_by_status = {status: [] for status in statuses}

--- a/workspace/utils/shorthands.py
+++ b/workspace/utils/shorthands.py
@@ -1,0 +1,6 @@
+ORGS = {
+    "os": "opensafely",
+    "osc": "opensafely-core",
+    "ebm": "ebmdatalab",
+    "bo": "bennettoxford",
+}

--- a/workspace/workflows/config.py
+++ b/workspace/workflows/config.py
@@ -1,10 +1,3 @@
-SHORTHANDS = {
-    "os": "opensafely",
-    "osc": "opensafely-core",
-    "ebm": "ebmdatalab",
-    "bo": "bennettoxford",
-}
-
 TEAMS = [
     "Tech shared",
     "Team REX",

--- a/workspace/workflows/jobs.py
+++ b/workspace/workflows/jobs.py
@@ -7,6 +7,7 @@ from urllib.parse import urljoin
 import requests
 
 from bennettbot import settings
+from workspace.utils import shorthands
 from workspace.utils.argparse import SplitString
 from workspace.utils.blocks import (
     get_basic_header_and_text_blocks,
@@ -364,8 +365,8 @@ def _main(targets: list[str], skip_successful: bool) -> str:
         else:  # Assume target is an org
             org, repo = target, None
 
-        org = config.SHORTHANDS.get(org, org)
-        if org not in config.SHORTHANDS.values():
+        org = shorthands.ORGS.get(org, org)
+        if org not in shorthands.ORGS.values():
             return report_invalid_target(target)
         if repo:
             locations.append(f"{org}/{repo}")
@@ -398,7 +399,7 @@ def get_text_blocks_for_key(args) -> str:
 
 
 def get_usage_text(args) -> str:
-    orgs = ", ".join([f"`{k} ({v})`" for k, v in config.SHORTHANDS.items()])
+    orgs = ", ".join([f"`{k} ({v})`" for k, v in shorthands.ORGS.items()])
     return "\n".join(
         [
             "Usage for `show [target]` (The behaviour for `show-failed [target]` is the same, but skips repos whose workflows are all successful):",


### PR DESCRIPTION
- This will allow the user to get boards outside of the opensafely-core
org on Slack.
- Since the boards fetched by Bennett Bot might be internal or private,
restrict all the report commands to internal users only.

The second and third commits comprise a quality of life change to avoid the user having to type the full organisation name to call the command.