### PR TITLE
Add a pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## Describe your changes
+
+## Issue ticket number and link
+
+## If adding/updating a custom BennettBot command, please check:
+
+- [ ] Unit tests added and coverage passing
+- [ ] Slack config updated (jobs/config.py)
+- [ ] Tested manually using slack test environment (or ask a member of the tech team to test your branch for you)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,5 +5,5 @@
 ## If adding/updating a custom BennettBot command, please check:
 
 - [ ] Unit tests added and coverage passing
-- [ ] Slack config updated (jobs/config.py)
+- [ ] Slack config updated (`bennettbot/job_configs.py`)
 - [ ] Tested manually using slack test environment (or ask a member of the tech team to test your branch for you)


### PR DESCRIPTION
Updates to BennettBot's custom commands can sometimes require update to config which isn't obvious (e.g. adding a new argument to a command doesn't trigger the standard config build checks, but won't be callable from slack without config updates).

This PR just adds a PR template to remind authors to make sure they've checked that their changes actually work for real from slack