### PR TITLE
Allow configuration for whether a job calls tech support upon failure

### DIFF
--- a/bennettbot/dispatcher.py
+++ b/bennettbot/dispatcher.py
@@ -128,9 +128,12 @@ class JobDispatcher:
         required."""
 
         error = rc != 0
-        # Don't repost to tech-support if we're in a DM with the bot, because no-one
-        # else will be able to read the reposted message
-        repost_to_tech_support_on_error = not self.job["is_im"]
+        repost_to_tech_support_on_error = (
+            # Call tech-support unless specified otherwise in the job config
+            # But not if we're in a DM with the bot, because no-one
+            # else will be able to read the reposted message
+            self.job_config["call_tech_support_on_error"] and not self.job["is_im"]
+        )
         if not error:
             if self.job_config["report_stdout"]:
                 with open(self.stdout_path) as f:

--- a/bennettbot/dispatcher.py
+++ b/bennettbot/dispatcher.py
@@ -127,8 +127,8 @@ class JobDispatcher:
         """Send notification that command has ended, reporting stdout if
         required."""
 
-        error = False
-        if rc == 0:
+        error = rc != 0
+        if not error:
             if self.job_config["report_stdout"]:
                 with open(self.stdout_path) as f:
                     if self.job_config["report_format"] == "blocks":
@@ -151,14 +151,13 @@ class JobDispatcher:
             )
             if not self.job["is_im"]:
                 msg += "\nCalling tech-support."
-            error = True
 
         slack_message = notify_slack(
             self.slack_client,
             self.job["channel"],
             msg,
             thread_ts=self.job["thread_ts"],
-            message_format=self.job_config["report_format"] if rc == 0 else "text",
+            message_format=self.job_config["report_format"] if not error else "text",
         )
         if error and not self.job["is_im"]:
             # If the command failed, repost it to tech-support

--- a/bennettbot/job_configs.py
+++ b/bennettbot/job_configs.py
@@ -619,6 +619,9 @@ def build_config(raw_config):
             job_config["report_stdout"] = job_config.get("report_stdout", False)
             job_config["report_format"] = job_config.get("report_format", "text")
             job_config["report_success"] = job_config.get("report_success", True)
+            job_config["call_tech_support_on_error"] = job_config.get(
+                "call_tech_support_on_error", True
+            )
             namespaced_job_type = f"{namespace}_{job_type}"
             validate_job_config(namespaced_job_type, job_config)
             config["jobs"][namespaced_job_type] = job_config
@@ -693,6 +696,7 @@ def validate_job_config(job_type, job_config):
         "report_stdout",
         "report_format",
         "report_success",
+        "call_tech_support_on_error",
     }
 
     if missing_keys := (expected_keys - job_config.keys()):

--- a/tests/job_configs.py
+++ b/tests/job_configs.py
@@ -28,6 +28,10 @@ raw_config = {
             "bad_job": {
                 "run_args_template": "cat no-poem",
             },
+            "unsupported_bad_job": {
+                "run_args_template": "cat no-poem",
+                "call_tech_support_on_error": False,
+            },
             "really_bad_job": {
                 "run_args_template": "dog poem",
             },

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -219,6 +219,26 @@ def test_job_failure():
         assert f.read() == "cat: no-poem: No such file or directory\n"
 
 
+def test_job_failure_but_configured_not_to_call_tech_support():
+    log_dir = build_log_dir("test_unsupported_bad_job")
+
+    scheduler.schedule_job("test_unsupported_bad_job", {}, "channel", TS, 0)
+    job = scheduler.reserve_job()
+    do_job(slack_web_client(), job)
+    assert_slack_client_sends_messages(
+        messages_kwargs=[
+            {"channel": "logs", "text": "about to start"},
+            {"channel": "channel", "text": "failed"},
+        ]
+    )
+
+    with open(os.path.join(log_dir, "stdout")) as f:
+        assert f.read() == ""
+
+    with open(os.path.join(log_dir, "stderr")) as f:
+        assert f.read() == "cat: no-poem: No such file or directory\n"
+
+
 def test_job_failure_in_dm():
     log_dir = build_log_dir("test_bad_job")
 

--- a/tests/test_job_configs.py
+++ b/tests/test_job_configs.py
@@ -29,6 +29,10 @@ def test_build_config():
             "jobs": {
                 "good_job": {"run_args_template": "cat {poem}", "report_stdout": True},
                 "bad_job": {"run_args_template": "dog {poem}", "report_success": False},
+                "unsupported_bad_job": {
+                    "run_args_template": "dog {poem}",
+                    "call_tech_support_on_error": False,
+                },
             },
             "slack": [
                 {
@@ -76,42 +80,56 @@ def test_build_config():
     assert config == {
         "jobs": {
             "ns1_good_job": {
+                "call_tech_support_on_error": True,
                 "run_args_template": "cat {poem}",
                 "report_stdout": False,
                 "report_format": "text",
                 "report_success": True,
             },
             "ns1_bad_job": {
+                "call_tech_support_on_error": True,
                 "run_args_template": "dog {poem}",
                 "report_stdout": False,
                 "report_format": "text",
                 "report_success": True,
             },
             "ns2_good_job": {
+                "call_tech_support_on_error": True,
                 "run_args_template": "cat {poem}",
                 "report_stdout": True,
                 "report_format": "text",
                 "report_success": True,
             },
             "ns2_bad_job": {
+                "call_tech_support_on_error": True,
                 "run_args_template": "dog {poem}",
                 "report_stdout": False,
                 "report_format": "text",
                 "report_success": False,
             },
+            "ns2_unsupported_bad_job": {
+                "call_tech_support_on_error": False,
+                "run_args_template": "dog {poem}",
+                "report_stdout": False,
+                "report_format": "text",
+                "report_success": True,
+            },
             "ns3_good_python_job": {
+                "call_tech_support_on_error": True,
                 "run_args_template": "python jobs.py",
                 "report_stdout": True,
                 "report_format": "text",
                 "report_success": True,
             },
             "ns3_bad_python_job": {
+                "call_tech_support_on_error": True,
                 "run_args_template": "python jobs.py",
                 "report_stdout": True,
                 "report_format": "text",
                 "report_success": True,
             },
             "test_good_job": {
+                "call_tech_support_on_error": True,
                 "run_args_template": "echo Hello",
                 "report_stdout": False,
                 "report_format": "text",


### PR DESCRIPTION
## Describe your changes
Some jobs alert tech support on failure, but there is nothing much that tech support can do. We can add a key to the job config dict called `"call_tech_support_on_error"`.

If this is explicitly set to `False`, then Bennett Bot won't repost the failure message to the tech support channel. 

## Issue ticket number and link
Closes #635 

## If adding/updating a custom BennettBot command, please check:
(Not adding a command but adding a config)

- [x] Unit tests added and coverage passing
- [x] Slack config updated (`bennettbot/job_configs.py`)
- [x] Tested manually using slack test environment (or ask a member of the tech team to test your branch for you)
