### PR TITLE
Unpin pip

### DIFF
--- a/justfile
+++ b/justfile
@@ -31,7 +31,7 @@ virtualenv:
     PYTHON_VERSION=${PYTHON_VERSION:-$DEFAULT_PYTHON}
 
     # create venv and install latest pip that's compatible with pip-tools
-    test -d $VIRTUAL_ENV || { $PYTHON_VERSION -m venv $VIRTUAL_ENV && $PIP install pip==25.0.1; }
+    test -d $VIRTUAL_ENV || { $PYTHON_VERSION -m venv $VIRTUAL_ENV && $PIP install --upgrade pip; }
 
     # ensure we have pip-tools so we can run pip-compile
     test -e $BIN/pip-compile || $PIP install pip-tools

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -12,6 +12,3 @@ pytest-cov
 pytest-env
 pytest-freezer
 mocket
-# The following is a work-around for a bug in pip-compile. For more information, see:
-# https://github.com/jazzband/pip-tools/issues/2176
-pip==25.0.1

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -323,9 +323,9 @@ wheel==0.45.1 \
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==25.0.1 \
-    --hash=sha256:88f96547ea48b940a3a385494e181e29fb8637898f88d88737c5049780f196ea \
-    --hash=sha256:c46efd13b6aa8279f33f2864459c8ce587ea6a1a59ee20de055868d8f7688f7f
+pip==25.2 \
+    --hash=sha256:578283f006390f85bb6282dffb876454593d637f5d1be494b5202ce4877e71f2 \
+    --hash=sha256:6d67a2b4e7f14d8b31b8b52648866fa717f45a1eb70e83002f4331d07e953717
     # via
     #   -r requirements.dev.in
     #   pip-tools


### PR DESCRIPTION
## Describe your changes

Unpin the `pip` version so that we can update to newer versions (for compatibility and security fixes).

It was pinned due to an incompatibility with pip-tools, which is now resolved.